### PR TITLE
Separate SummerExecutor interface and it implementation

### DIFF
--- a/summer/src/commonMain/kotlin/summer/SummerPresenterWithRouter.kt
+++ b/summer/src/commonMain/kotlin/summer/SummerPresenterWithRouter.kt
@@ -1,5 +1,6 @@
 package summer
 
+import summer.execution.SummerExecutor
 import summer.store.InMemoryStore
 import summer.store.SummerStore
 import kotlin.coroutines.CoroutineContext
@@ -13,9 +14,11 @@ abstract class SummerPresenterWithRouter<TViewState, TViewMethods, TRouter>(
      */
     localStore: SummerStore = InMemoryStore()
 ) : SummerPresenter<TViewState, TViewMethods>(
-    uiContext,
-    defaultWorkContext,
-    loggerFactory,
+    SummerExecutor(
+        uiContext = uiContext,
+        defaultWorkContext = defaultWorkContext,
+        loggerFactory = loggerFactory
+    ),
     localStore
 ) {
     protected val router: TRouter

--- a/summer/src/commonMain/kotlin/summer/execution/SummerInterceptor.kt
+++ b/summer/src/commonMain/kotlin/summer/execution/SummerInterceptor.kt
@@ -84,3 +84,15 @@ class LoadingExecutorInterceptor<TEntity, TParams>(
         property.set(false)
     }
 }
+
+/**
+ * Factory method for [LoadingExecutorInterceptor]
+ */
+@Suppress("FunctionName")
+fun <TEntity, TParams> LoadingInterceptor(
+    getProperty: suspend () -> KMutableProperty0<Boolean>,
+    needShow: suspend (event: SummerExecutorInterceptor.Event.Executed<TEntity, TParams>) -> Boolean = { true }
+): LoadingExecutorInterceptor<TEntity, TParams> = LoadingExecutorInterceptor(
+    getProperty = getProperty,
+    needShow = needShow
+)

--- a/summer/src/commonMain/kotlin/summer/execution/mix/MixSourceExecutor.kt
+++ b/summer/src/commonMain/kotlin/summer/execution/mix/MixSourceExecutor.kt
@@ -53,4 +53,7 @@ class MixSourceExecutor<T, TSourceParams> internal constructor(
     }
 }
 
+/**
+ * Shorthand for [MixSourceExecutor.execute] when MixSourceExecutor.TSourceParams is Unit
+ */
 fun <T> MixSourceExecutor<T, Unit>.execute() = execute(Unit)

--- a/summer/src/commonMain/kotlin/summer/execution/reducer/ReducerExecutor.kt
+++ b/summer/src/commonMain/kotlin/summer/execution/reducer/ReducerExecutor.kt
@@ -53,4 +53,7 @@ class ReducerExecutor<TEntity, in TParams> internal constructor(
     }
 }
 
+/**
+ * Shorthand for [ReducerExecutor.execute] when ReducerExecutor.TParams is Unit
+ */
 fun <TEntity> ReducerExecutor<TEntity, Unit>.execute() = execute(Unit)

--- a/summer/src/commonMain/kotlin/summer/execution/source/SourceExecutor.kt
+++ b/summer/src/commonMain/kotlin/summer/execution/source/SourceExecutor.kt
@@ -111,3 +111,8 @@ fun <TEntity> SourceExecutor<TEntity, Unit>.execute(
     params = Unit,
     cancelAll = cancelAll
 )
+
+/**
+ * Shorthand for [SourceExecutor.execute] when SourceExecutor.TParams is Unit
+ */
+fun <TEntity> SourceExecutor<TEntity, Unit>.execute() = execute(Unit)

--- a/summer/src/jvmTest/kotlin/summer/MixTests.kt
+++ b/summer/src/jvmTest/kotlin/summer/MixTests.kt
@@ -1,6 +1,7 @@
 package summer
 
 import kotlinx.coroutines.Dispatchers
+import summer.execution.LifecycleSummerExecutor
 import summer.execution.SummerExecutor
 import summer.execution.mix.execute
 import summer.execution.reducer.SummerReducer
@@ -26,7 +27,7 @@ class MixTests {
 
         lateinit var actualResult: String
 
-        val summerExecutor = object : SummerExecutor(Dispatchers.Unconfined, Dispatchers.Unconfined, loggersFactory) {
+        val summerExecutor = object : LifecycleSummerExecutor by SummerExecutor(Dispatchers.Unconfined, Dispatchers.Unconfined, loggersFactory) {
 
             val reducer = object : SummerReducer<String, Unit>(this) {
 
@@ -71,7 +72,7 @@ class MixTests {
 
         lateinit var actualResult: String
 
-        val summerExecutor = object : SummerExecutor(Dispatchers.Unconfined, Dispatchers.Unconfined, loggersFactory) {
+        val summerExecutor = object : LifecycleSummerExecutor by SummerExecutor(Dispatchers.Unconfined, Dispatchers.Unconfined, loggersFactory) {
 
             val reducer = object : SummerReducer<String, Unit>(this) {
 

--- a/summer/src/jvmTest/kotlin/summer/ReducerExecutorTests.kt
+++ b/summer/src/jvmTest/kotlin/summer/ReducerExecutorTests.kt
@@ -1,6 +1,8 @@
 package summer
 
 import kotlinx.coroutines.Dispatchers
+import summer.execution.DefaultSummerExecutor
+import summer.execution.LifecycleSummerExecutor
 import summer.execution.SummerExecutor
 import summer.execution.reducer.SummerReducer
 import java.lang.RuntimeException
@@ -17,7 +19,7 @@ class ReducerExecutorTests {
 
         lateinit var actualResult: String
 
-        val summerExecutor = object : SummerExecutor(Dispatchers.Unconfined, Dispatchers.Unconfined, loggersFactory) {
+        val summerExecutor = object : LifecycleSummerExecutor by SummerExecutor(Dispatchers.Unconfined, Dispatchers.Unconfined, loggersFactory) {
 
             val reducer = object : SummerReducer<String, Unit>(this) {
 
@@ -49,7 +51,7 @@ class ReducerExecutorTests {
 
         lateinit var throwable: Throwable
 
-        val summerExecutor = object : SummerExecutor(Dispatchers.Unconfined, Dispatchers.Unconfined, loggersFactory) {
+        val summerExecutor = object : LifecycleSummerExecutor by SummerExecutor(Dispatchers.Unconfined, Dispatchers.Unconfined, loggersFactory) {
 
             val reducer = object : SummerReducer<String, Unit>(this) {
 

--- a/summer/src/jvmTest/kotlin/summer/SourceExecutorTests.kt
+++ b/summer/src/jvmTest/kotlin/summer/SourceExecutorTests.kt
@@ -3,9 +3,8 @@ package summer
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
-import summer.execution.DeferredExecutor
-import summer.execution.NoInterceptor
-import summer.execution.SummerExecutor
+import kotlinx.coroutines.runBlocking
+import summer.execution.*
 import summer.execution.source.SourceExecutor
 import summer.execution.source.SummerSource
 import summer.execution.source.execute
@@ -23,7 +22,7 @@ class SourceExecutorTests {
 
         val expectedResult = "test"
 
-        val scope = object : SummerExecutor(Dispatchers.Unconfined, Dispatchers.Unconfined, loggersFactory) {}
+        val scope = SummerExecutor(Dispatchers.Unconfined, Dispatchers.Unconfined, loggersFactory)
         val deferredExecutor = DeferredExecutor(scope)
 
         val source = object : SummerSource<String, Unit> {
@@ -56,7 +55,7 @@ class SourceExecutorTests {
     @Test
     fun fail() {
 
-        val scope = object : SummerExecutor(Dispatchers.Unconfined, Dispatchers.Unconfined, loggersFactory) {}
+        val scope = SummerExecutor(Dispatchers.Unconfined, Dispatchers.Unconfined, loggersFactory)
         val deferredExecutor = DeferredExecutor(scope)
 
         val source = object : SummerSource<String, Unit> {
@@ -89,7 +88,7 @@ class SourceExecutorTests {
     @Test
     fun cancel() {
 
-        val scope = object : SummerExecutor(Dispatchers.Unconfined, Dispatchers.Unconfined, loggersFactory) {}
+        val scope = SummerExecutor(Dispatchers.Unconfined, Dispatchers.Unconfined, loggersFactory)
         val deferredExecutor = DeferredExecutor(scope)
 
         val source = object : SummerSource<String, Unit> {
@@ -128,7 +127,7 @@ class SourceExecutorTests {
     @Test
     fun cancelBeforeLaunch() {
 
-        val scope = object : SummerExecutor(Dispatchers.Unconfined, Dispatchers.Unconfined, loggersFactory) {}
+        val scope = SummerExecutor(Dispatchers.Unconfined, Dispatchers.Unconfined, loggersFactory)
         val deferredExecutor = DeferredExecutor(scope)
 
         val source = object : SummerSource<String, Unit> {


### PR DESCRIPTION
First stap to implement PresenterDelegate.
Now it's possible to use SummerExecutor not only in SummerPresenter class because of implement  SummerExecutor as an interface.