### PR TITLE
Fix failed test of cancellation SummerSource.

### DIFF
--- a/summer/src/jvmTest/kotlin/summer/SourceExecutorTests.kt
+++ b/summer/src/jvmTest/kotlin/summer/SourceExecutorTests.kt
@@ -3,6 +3,7 @@ package summer
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 import summer.execution.DeferredExecutor
 import summer.execution.NoInterceptor
 import summer.execution.SummerExecutor
@@ -87,7 +88,7 @@ class SourceExecutorTests {
     }
 
     @Test
-    fun cancel() {
+    fun cancel() = runBlocking {
 
         val scope = object : SummerExecutor(Dispatchers.Unconfined, Dispatchers.Unconfined, loggersFactory) {}
         val deferredExecutor = DeferredExecutor(scope)
@@ -119,7 +120,7 @@ class SourceExecutorTests {
         )
 
         executor.execute()
-        scope.cancel()
+        executor.cancelAll()
 
         assertNull(throwable)
         assertTrue(isCancelled)


### PR DESCRIPTION
Cancel SummerSource test was failed because of cancellation scope in witch SummerSource was running (it's an equivalent of destroying presenter). So it was ok that onCancel hook was not calling.
Scope cancellation was replaced with executor cancellation witch is the case when onCancel hook should be called.