### PR TITLE
Fix onFailure method called if onFailure hook was't throw exception.

### DIFF
--- a/summer/src/commonMain/kotlin/summer/execution/mix/MixSourceExecutor.kt
+++ b/summer/src/commonMain/kotlin/summer/execution/mix/MixSourceExecutor.kt
@@ -37,16 +37,19 @@ class MixSourceExecutor<T, TSourceParams> internal constructor(
     }
 
     override fun onObtain(deferred: Deferred<T>, sourceParams: TSourceParams) {
-        scope.launch {
+        deferredExecutor.launch(
+            initialScope = scope,
+            params = sourceParams,
+            onFailure = onFailure
+        ) {
             withContext(workContext) {
                 deferredExecutor.execute(
                     deferred = deferred,
                     params = sourceParams,
                     interceptor = interceptor,
-                    onFailure = onFailure,
                     onExecute = onExecute,
-                    onCancel = onCancel,
-                    onSuccess = onSuccess
+                    onSuccess = onSuccess,
+                    onCancel = onCancel
                 )
             }
         }

--- a/summer/src/commonMain/kotlin/summer/execution/reducer/ReducerExecutor.kt
+++ b/summer/src/commonMain/kotlin/summer/execution/reducer/ReducerExecutor.kt
@@ -3,7 +3,6 @@ package summer.execution.reducer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
-import kotlinx.coroutines.launch
 import summer.SummerPresenter
 import summer.execution.DeferredExecutor
 import summer.execution.SummerExecutor
@@ -36,7 +35,11 @@ class ReducerExecutor<TEntity, in TParams> internal constructor(
     }
 
     override fun onObtain(deferred: Deferred<TEntity>, params: TParams?) {
-        scope.launch {
+        deferredExecutor.launch(
+            initialScope = scope,
+            params = params,
+            onFailure = onFailure
+        ) {
             val scopedDeferred = async(workContext) {
                 deferred.await()
             }
@@ -44,10 +47,9 @@ class ReducerExecutor<TEntity, in TParams> internal constructor(
                 deferred = scopedDeferred,
                 params = params,
                 interceptor = interceptor,
-                onFailure = onFailure,
                 onExecute = onExecute,
-                onCancel = onCancel,
-                onSuccess = onSuccess
+                onSuccess = onSuccess,
+                onCancel = onCancel
             )
         }
     }

--- a/summer/src/commonMain/kotlin/summer/execution/source/SourceExecutor.kt
+++ b/summer/src/commonMain/kotlin/summer/execution/source/SourceExecutor.kt
@@ -1,9 +1,6 @@
 package summer.execution.source
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import summer.SummerPresenter
 import summer.execution.DeferredExecutor
 import summer.execution.SummerExecutor
@@ -34,7 +31,11 @@ class SourceExecutor<TEntity, TParams> internal constructor(
         if (cancelAll) {
             cancelAll()
         }
-        val job = scope.launch {
+        val job = deferredExecutor.launch(
+            initialScope = scope,
+            params = params,
+            onFailure = onFailure
+        ) {
             try {
                 val deferred = async(workContext) {
                     source(params)
@@ -45,7 +46,6 @@ class SourceExecutor<TEntity, TParams> internal constructor(
                     interceptor = interceptor,
                     onExecute = onExecute,
                     onSuccess = onSuccess,
-                    onFailure = onFailure,
                     onCancel = onCancel
                 )
             } finally {


### PR DESCRIPTION
It was with add coroutineExceptionHandler to original scope.
For any exception in launch new coroutine inside original scope and call onFailure. 
So, if onFailure throw an exception -> original coroutineExceptionHandler will be called -> onFailure method will be called. Otherwise, onFailure method will not be called.
CancellationException is handled with try/catch, because coroutineExceptionHandler is not called for this type of ex exception.